### PR TITLE
Add Microsoft 365 Office uninstall job

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1359,6 +1359,17 @@ winget uninstall --name "Microsoft 365 Copilot" --exact --all-versions
 ```
 
 
+#### Microsoft 365 (Office)
+
+Uninstalls `Microsoft 365 (Office)` using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/).
+
+##### Command to manually apply:
+
+```ps
+winget uninstall --name "Microsoft 365 (Office)" --exact --all-versions
+```
+
+
 #### Copilot
 
 Uninstalls `Copilot` using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/).

--- a/src/WinDebloat/Program_Groups.cs
+++ b/src/WinDebloat/Program_Groups.cs
@@ -98,6 +98,7 @@
             [
                 new UninstallByNameJob("Microsoft Copilot"),
                 new UninstallByNameJob("Microsoft 365 Copilot"),
+                new UninstallByNameJob("Microsoft 365 (Office)"),
                 new UninstallByNameJob("Copilot"),
                 new RegistryValueJob(
                     RegistryHive.LocalMachine,

--- a/src/actions.include.md
+++ b/src/actions.include.md
@@ -1293,6 +1293,17 @@ winget uninstall --name "Microsoft 365 Copilot" --exact --all-versions
 ```
 
 
+#### Microsoft 365 (Office)
+
+Uninstalls `Microsoft 365 (Office)` using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/).
+
+##### Command to manually apply:
+
+```ps
+winget uninstall --name "Microsoft 365 (Office)" --exact --all-versions
+```
+
+
 #### Copilot
 
 Uninstalls `Copilot` using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/).


### PR DESCRIPTION
Extend the Copilot-related debloat group to also uninstall the "Microsoft 365 (Office)" package. This keeps app removal coverage aligned with current Microsoft naming and bundled variants.